### PR TITLE
`_resetTimePeriodic()` in MqttClient does not end even after it closed

### DIFF
--- a/dart_mqtt/lib/src/client.dart
+++ b/dart_mqtt/lib/src/client.dart
@@ -15,6 +15,7 @@ class MqttClient {
   bool _started = false;
   bool _paused = false;
   bool _stoped = false;
+  bool _disposed = false;
   bool log = false;
 
   final _buf = MqttBuffer();
@@ -211,6 +212,12 @@ class MqttClient {
     transport.close();
   }
 
+  /// eliminate functionality
+  void dispose() {
+    _disposed = true; // to stop recursive calls of `_resetTimePeriodic()`
+    stop();
+  }
+
   void _onConnectClose() {
     if (_stoped) return; //return if stoped
 
@@ -236,6 +243,8 @@ class MqttClient {
   }
 
   void _resetTimePeriodic() {
+    if(_disposed) return; // to stop recursive calls of `_resetTimePeriodic()`
+
     if (transport.status != ConnectStatus.connected) {
       loger.log("_resetTimePeriodic: ${transport.status}");
     }


### PR DESCRIPTION
MqttClient does not clear reset timer inside `_resetTimePeriodic()` when calling `stop()` or `close()`.

I added the `dispose()` to turn off the recursive call of `_resetTimePeriodic()`.

It is a necessary for reconnecting new end point of mqtt broker having  different ip and port.