### PR TITLE
Exception: RangeError when reading the buffer;

### DIFF
--- a/dart_mqtt/lib/src/client.dart
+++ b/dart_mqtt/lib/src/client.dart
@@ -320,7 +320,7 @@ class MqttClient {
     });
     transport.onMessage((msg) {
       _buf.addAll(msg.message);
-      while(_buf.bytes.length > 0){
+      while(_buf.availableBytes > 0){
         late MqttMessage pack;
         if (lasthead != null) {
           if (_buf.availableBytes < lasthead!.remainingLength) {


### PR DESCRIPTION
[ERROR:flutter/runtime/dart_vm_initializer.cc(40)] Unhandled Exception: RangeError (length): Invalid value: Not in inclusive range 0..281: 282
#0      List.[] (dart:core-patch/growable_array.dart)
#1      MqttBuffer.readBits (package:dart_mqtt/src/utility/dart_mqtt_byte_buffer.dart:65:21)
dart_mqtt_byte_buffer.dart:65
#2      new MqttFixedHead.readFrom (package:dart_mqtt/src/messages/dart_mqtt_head.dart:7:28)